### PR TITLE
Add Hive-based caching for OpenAI emergency instructions

### DIFF
--- a/brigadeflutter/lib/core/workers/openai_isolate.dart
+++ b/brigadeflutter/lib/core/workers/openai_isolate.dart
@@ -22,6 +22,8 @@
 // }
 
 import 'dart:isolate';
+import 'package:hive/hive.dart';
+
 import '../../data/services_external/openai_service.dart';
 
 // Include the key as argument instead of reading dotenv again
@@ -29,10 +31,17 @@ class OpenAIIsolateMessage {
   final SendPort sendPort;
   final String emergencyType;
   final String apiKey;
-  OpenAIIsolateMessage(this.sendPort, this.emergencyType, this.apiKey);
+  final String appDocPath;
+  OpenAIIsolateMessage(this.sendPort, this.emergencyType, this.apiKey, this.appDocPath);
 }
 
 Future<void> openAIIsolateEntry(OpenAIIsolateMessage message) async {
+    try {
+    Hive.init(message.appDocPath);
+  } catch (_) {
+    // ignore if already initialized
+  }
+
   try {
     final service = OpenAIServiceImpl.withKey(message.apiKey);
     final result = await service.getInstructionText(

--- a/brigadeflutter/lib/data/services_external/openai_service.dart
+++ b/brigadeflutter/lib/data/services_external/openai_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:hive/hive.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
@@ -16,19 +17,38 @@ class OpenAIServiceImpl implements OpenAIService {
 
   @override
   Future<String> getInstructionText({required String emergencyType}) async {
+    final box = await Hive.openBox<String>('ai_cache');
+    final key = emergencyType.toLowerCase().trim();
+
+    // check cache first
+    final cached = box.get(key);
+    if (cached != null) {
+      return cached;
+    }
+
     if (_apiKey.isEmpty) {
       throw Exception('missing OPENAI_API_KEY');
     }
 
     final res = await http.post(
       Uri.parse(_endpoint),
-      headers: {'Authorization': 'Bearer $_apiKey','Content-Type': 'application/json'},
+      headers: {
+        'Authorization': 'Bearer $_apiKey',
+        'Content-Type': 'application/json',
+      },
       body: jsonEncode({
         'model': _model,
         'temperature': 0.2,
         'messages': [
-          {'role': 'system','content': 'You are a safety assistant. Give clear, short steps.'},
-          {'role': 'user','content': 'Give 4–6 numbered steps for emergency: "$emergencyType". Keep it concise.'}
+          {
+            'role': 'system',
+            'content': 'You are a safety assistant. Give clear, short steps.',
+          },
+          {
+            'role': 'user',
+            'content':
+                'Give 2-4 numbered steps for emergency: "$emergencyType". Keep it concise.',
+          },
         ],
       }),
     );
@@ -37,6 +57,19 @@ class OpenAIServiceImpl implements OpenAIService {
       throw Exception('OpenAI ${res.statusCode}: ${res.body}');
     }
     final data = json.decode(res.body) as Map<String, dynamic>;
-    return (data['choices']?[0]?['message']?['content'] ?? '').toString().trim();
+
+    final text = (data['choices']?[0]?['message']?['content'] ?? '')
+        .toString()
+        .trim();
+
+    // cache result
+    await box.put(
+      key,
+      jsonEncode({
+        'text': text,
+        'timestamp': DateTime.now().millisecondsSinceEpoch,
+      }),
+    );
+    return text;
   }
 }

--- a/brigadeflutter/lib/main.dart
+++ b/brigadeflutter/lib/main.dart
@@ -22,6 +22,7 @@ Future<void> main() async {
   await dotenv.load(fileName: '.env'); // optional
   await Hive.initFlutter();
   await Hive.openBox('trainingsBox');
+  await Hive.openBox<String>('ai_cache'); //register box for openai cache
 
   // initialize firebase if used
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);

--- a/brigadeflutter/lib/presentation/viewmodels/emergency_report_viewmodel.dart
+++ b/brigadeflutter/lib/presentation/viewmodels/emergency_report_viewmodel.dart
@@ -4,6 +4,7 @@ import 'package:brigadeflutter/data/models/report_model.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:path_provider/path_provider.dart';
 import '../../domain/use_cases/create_emergency_report.dart';
 import '../../domain/use_cases/fill_location.dart';
 import '../../domain/use_cases/adjust_brightness_from_ambient.dart';
@@ -170,10 +171,13 @@ class EmergencyReportViewModel extends ChangeNotifier {
       final receivePort = ReceivePort();
       final apiKey = dotenv.env['OPENAI_API_KEY'] ?? '';
       final typeName = type.isEmpty ? 'Emergency' : type;
+      final dir = await getApplicationDocumentsDirectory();
+      final appPath = dir.path;
+
 
       await Isolate.spawn(
         openAIIsolateEntry,
-        OpenAIIsolateMessage(receivePort.sendPort, typeName, apiKey),
+        OpenAIIsolateMessage(receivePort.sendPort, typeName, apiKey, appPath),
       );
 
       final result = await receivePort.first as String;


### PR DESCRIPTION
Introduces a Hive box ('ai_cache') to cache OpenAI emergency instruction responses, reducing redundant API calls. Updates the OpenAI isolate and service to initialize and use the cache, and ensures the app document path is passed to isolates for Hive initialization. Also updates the prompt to request 2-4 steps instead of 4-6.