### PR TITLE
Leaderboard connectivity

### DIFF
--- a/brigadeflutter/lib/data/cache/leaderboard_cache_manager.dart
+++ b/brigadeflutter/lib/data/cache/leaderboard_cache_manager.dart
@@ -10,7 +10,7 @@ class LeaderboardCacheManager {
   LeaderboardCacheManager({CacheManager? cacheManager})
       : _cacheManager = cacheManager ?? DefaultCacheManager();
 
-  /// Save leaderboard to cache
+  /// guardar leaderboard a cache
   Future<void> saveLeaderboard(List<LeaderboardEntry> entries, String weekId) async {
     final jsonData = {
       "weekId": weekId,
@@ -29,7 +29,7 @@ class LeaderboardCacheManager {
     await _cacheManager.putFile(
       _cacheKey,
       utf8.encode(jsonString),
-      maxAge: const Duration(days: 7), // leaderboard refresh every week
+      maxAge: const Duration(days: 7), // recargar cada 7 dias
     );
   }
 

--- a/brigadeflutter/lib/data/cache/leaderboard_cache_manager.dart
+++ b/brigadeflutter/lib/data/cache/leaderboard_cache_manager.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import '../../presentation/viewmodels/leaderboard_viewmodel.dart';
+
+class LeaderboardCacheManager {
+  static const String _cacheKey = 'leaderboard_cache';
+
+  final CacheManager _cacheManager;
+
+  LeaderboardCacheManager({CacheManager? cacheManager})
+      : _cacheManager = cacheManager ?? DefaultCacheManager();
+
+  /// Save leaderboard to cache
+  Future<void> saveLeaderboard(List<LeaderboardEntry> entries, String weekId) async {
+    final jsonData = {
+      "weekId": weekId,
+      "entries": entries
+          .map((e) => {
+                "uid": e.uid,
+                "email": e.email,
+                "completedCount": e.completedCount,
+                "lastCompletedAt": e.lastCompletedAt?.toIso8601String(),
+              })
+          .toList(),
+    };
+
+    final jsonString = jsonEncode(jsonData);
+
+    await _cacheManager.putFile(
+      _cacheKey,
+      utf8.encode(jsonString),
+      maxAge: const Duration(days: 7), // leaderboard refresh every week
+    );
+  }
+
+  /// Load leaderboard from cache
+  Future<Map<String, dynamic>?> getCachedLeaderboard() async {
+    try {
+      final fileInfo = await _cacheManager.getFileFromCache(_cacheKey);
+      if (fileInfo == null) return null;
+
+      final jsonString = await fileInfo.file.readAsString();
+      return jsonDecode(jsonString);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  Future<void> clearCache() async {
+    await _cacheManager.removeFile(_cacheKey);
+  }
+}

--- a/brigadeflutter/lib/presentation/viewmodels/leaderboard_viewmodel.dart
+++ b/brigadeflutter/lib/presentation/viewmodels/leaderboard_viewmodel.dart
@@ -44,7 +44,7 @@ class LeaderboardViewModel extends ChangeNotifier {
     _loadedFromCache = false;
     notifyListeners();
 
-    // 1. Intentar cargar desde cache
+    // intentar cargar desde cache
     final cached = await _cacheManager.getCachedLeaderboard();
     if (cached != null) {
       _entries = (cached["entries"] as List<dynamic>).map((e) {
@@ -63,7 +63,7 @@ class LeaderboardViewModel extends ChangeNotifier {
       notifyListeners();
     }
 
-    // 2. Intentar Firestore
+    // intentar Firestore
     try {
       final String weekId = _getWeekId();
 
@@ -97,7 +97,7 @@ class LeaderboardViewModel extends ChangeNotifier {
       _cachedWeekId = weekId;
       _loadedFromCache = false;
 
-      // Guardar en cache
+      // guardar en cache
       await _cacheManager.saveLeaderboard(parsed, weekId);
 
     } catch (_) {

--- a/brigadeflutter/lib/presentation/viewmodels/leaderboard_viewmodel.dart
+++ b/brigadeflutter/lib/presentation/viewmodels/leaderboard_viewmodel.dart
@@ -1,50 +1,71 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
+import '../../data/cache/leaderboard_cache_manager.dart';
 
 String _getWeekId() {
   final now = DateTime.now();
   final oneJan = DateTime(now.year, 1, 1);
-
   final days = now.difference(oneJan).inMilliseconds / 86400000;
   final week = ((days + oneJan.weekday + 1) / 7).ceil();
-
   return "${now.year}-W$week";
 }
 
-
-
 class LeaderboardEntry {
+  final String uid;
+  final String email;
+  final int completedCount;
+  final DateTime? lastCompletedAt;
+
   LeaderboardEntry({
     required this.uid,
     required this.email,
     required this.completedCount,
     this.lastCompletedAt,
   });
-
-  final String uid;
-  final String email;
-  final int completedCount;
-  final DateTime? lastCompletedAt;
 }
 
 class LeaderboardViewModel extends ChangeNotifier {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final LeaderboardCacheManager _cacheManager = LeaderboardCacheManager();
 
   bool _loading = false;
-  DateTime? _lastUpdated;
+  bool _loadedFromCache = false;
+  String? _cachedWeekId;
+
   List<LeaderboardEntry> _entries = <LeaderboardEntry>[];
 
   bool get isLoading => _loading;
+  bool get loadedFromCache => _loadedFromCache;
   List<LeaderboardEntry> get entries => _entries;
+  String? get cachedWeekId => _cachedWeekId;
 
   Future<void> loadLeaderboard() async {
     _loading = true;
+    _loadedFromCache = false;
     notifyListeners();
 
+    // 1. Intentar cargar desde cache
+    final cached = await _cacheManager.getCachedLeaderboard();
+    if (cached != null) {
+      _entries = (cached["entries"] as List<dynamic>).map((e) {
+        return LeaderboardEntry(
+          uid: e["uid"],
+          email: e["email"],
+          completedCount: e["completedCount"],
+          lastCompletedAt: e["lastCompletedAt"] != null
+              ? DateTime.parse(e["lastCompletedAt"])
+              : null,
+        );
+      }).toList();
+
+      _cachedWeekId = cached["weekId"];
+      _loadedFromCache = true;
+      notifyListeners();
+    }
+
+    // 2. Intentar Firestore
     try {
       final String weekId = _getWeekId();
-
-      debugPrint(" WEEK ID en Flutter → $weekId");
 
       final doc = await _firestore
           .collection('weekly_leaderboard')
@@ -52,30 +73,38 @@ class LeaderboardViewModel extends ChangeNotifier {
           .get();
 
       if (!doc.exists) {
-        debugPrint("No leaderboard found");
-        _entries = [];
+        if (!_loadedFromCache) _entries = [];
+        _loading = false;
+        notifyListeners();
         return;
       }
 
       final data = doc.data()!;
-      final List<dynamic> rawEntries = data['entries'] ?? [];
+      final rawEntries = data['entries'] as List<dynamic>? ?? [];
 
-      final List<LeaderboardEntry> parsed = rawEntries.map((dynamic e) {
+      final parsed = rawEntries.map((e) {
         return LeaderboardEntry(
           uid: e['uid'] as String,
           email: e['emailPrefix'] as String,
           completedCount: e['completedCount'] as int,
-          lastCompletedAt: e['lastCompletedAt'] == null
-              ? null
-              : (e['lastCompletedAt'] as Timestamp).toDate(),
+          lastCompletedAt: e['lastCompletedAt'] != null
+              ? (e['lastCompletedAt'] as Timestamp).toDate()
+              : null,
         );
       }).toList();
 
       _entries = parsed;
-      _lastUpdated = DateTime.now();
-    } finally {
-      _loading = false;
-      notifyListeners();
+      _cachedWeekId = weekId;
+      _loadedFromCache = false;
+
+      // Guardar en cache
+      await _cacheManager.saveLeaderboard(parsed, weekId);
+
+    } catch (_) {
+      // si falla firestore, usa cache
     }
+
+    _loading = false;
+    notifyListeners();
   }
 }

--- a/brigadeflutter/lib/presentation/views/leaderboard_screen.dart
+++ b/brigadeflutter/lib/presentation/views/leaderboard_screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:brigadeflutter/presentation/viewmodels/leaderboard_viewmodel.dart';
 import '../components/connectivity_status_icon.dart';
-import '../viewmodels/leaderboard_viewmodel.dart';
+import '../viewmodels/auth_viewmodel.dart';
 
 class LeaderboardScreen extends StatelessWidget {
   const LeaderboardScreen({super.key});
@@ -12,52 +13,90 @@ class LeaderboardScreen extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Weekly Leaderboard', style: TextStyle(fontWeight: FontWeight.bold)),
+        title: const Text(
+          'Weekly Leaderboard',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
         backgroundColor: Colors.white,
-        actions: const <Widget>[
-          ConnectivityStatusIcon(),
-        ],
+        actions: const <Widget>[ConnectivityStatusIcon()],
       ),
       backgroundColor: const Color(0xFFF3F5F8),
       body: vm.isLoading
           ? const Center(child: CircularProgressIndicator())
-          : ListView.builder(
-              itemCount: vm.entries.length,
-              itemBuilder: (BuildContext context, int index) {
-                final LeaderboardEntry entry = vm.entries[index];
-                final String emailPrefix = entry.email.split('@').first;
-                final IconData? medalIcon = index == 0
-                    ? Icons.emoji_events
-                    : index == 1
-                        ? Icons.emoji_events_outlined
-                        : index == 2
-                            ? Icons.military_tech
-                            : null;
+          : Column(
+              children: [
+                // banner offline
+                Consumer<AuthViewModel>(
+                  builder: (_, authVM, __) {
+                    if (!authVM.isOnline) {
+                      // week ID real o cache
+                      final weekText = vm.cachedWeekId ?? "this week";
 
-                return ListTile(
-                  leading: CircleAvatar(
-                    backgroundColor: Colors.grey[300],
-                    child: medalIcon != null
-                        ? Icon(
-                            medalIcon,
-                            color: index == 0
-                                ? Colors.amber
-                                : index == 1
-                                    ? Colors.grey
-                                    : Colors.brown,
-                          )
-                        : Text('${index + 1}'),
+                      return Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(12),
+                        margin: const EdgeInsets.symmetric(vertical: 4),
+                        color: Colors.orange.shade100,
+                        child: Text(
+                          "You’re offline.\n\n"
+                          "You’re viewing Week $weekText leaderboard.\n"
+                          "Some results may be outdated until your connection is restored.\n"
+                          "Remember it is updated every Sunday at 11:59 pm.",
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.black87,
+                          ),
+                        ),
+                      );
+                    }
+                    return const SizedBox.shrink();
+                  },
+                ),
+
+                // MAIN LIST
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: vm.entries.length,
+                    itemBuilder: (BuildContext context, int index) {
+                      final LeaderboardEntry entry = vm.entries[index];
+                      final String emailPrefix = entry.email.split('@').first;
+                      final IconData? medalIcon = index == 0
+                          ? Icons.emoji_events
+                          : index == 1
+                          ? Icons.emoji_events_outlined
+                          : index == 2
+                          ? Icons.military_tech
+                          : null;
+
+                      return ListTile(
+                        leading: CircleAvatar(
+                          backgroundColor: Colors.grey[300],
+                          child: medalIcon != null
+                              ? Icon(
+                                  medalIcon,
+                                  color: index == 0
+                                      ? Colors.amber
+                                      : index == 1
+                                      ? Colors.grey
+                                      : Colors.brown,
+                                )
+                              : Text('${index + 1}'),
+                        ),
+                        title: Text(
+                          emailPrefix,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                        trailing: Text(
+                          '${entry.completedCount} cursos',
+                          style: const TextStyle(color: Colors.blueAccent),
+                        ),
+                      );
+                    },
                   ),
-                  title: Text(
-                    emailPrefix,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  trailing: Text(
-                    '${entry.completedCount} cursos',
-                    style: const TextStyle(color: Colors.blueAccent),
-                  ),
-                );
-              },
+                ),
+              ],
             ),
     );
   }

--- a/brigadeflutter/lib/presentation/views/leaderboard_screen.dart
+++ b/brigadeflutter/lib/presentation/views/leaderboard_screen.dart
@@ -25,11 +25,9 @@ class LeaderboardScreen extends StatelessWidget {
           ? const Center(child: CircularProgressIndicator())
           : Column(
               children: [
-                // banner offline
                 Consumer<AuthViewModel>(
                   builder: (_, authVM, __) {
                     if (!authVM.isOnline) {
-                      // week ID real o cache
                       final weekText = vm.cachedWeekId ?? "this week";
 
                       return Container(
@@ -55,7 +53,6 @@ class LeaderboardScreen extends StatelessWidget {
                   },
                 ),
 
-                // MAIN LIST
                 Expanded(
                   child: ListView.builder(
                     itemCount: vm.entries.length,


### PR DESCRIPTION
This PR adds full offline support to the Weekly Leaderboard feature by introducing local caching and a user-friendly offline banner. Users can now open the leaderboard even without connectivity, ensuring continuity of access and preventing UI blocks.

closes #117 
closes #116 